### PR TITLE
Tune CI setup

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -18,6 +18,6 @@ jobs:
     name: Publishing to Cargo
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo publish --token ${{ secrets.CARGO_API_TOKEN }}

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -9,7 +9,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -13,4 +13,6 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+
       - run: ./ci.sh

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -9,7 +9,7 @@ jobs:
   validate:
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -13,9 +13,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - uses: Swatinem/rust-cache@v2
 
-      # Copied from here:
-      # <https://docs.travis-ci.com/user/languages/rust/#default-build-script>
-      #
-      # FIXME: Replace "build" with "test" once it passes.
+      # FIXME: Replace "build" with "test" once it passes on Windows.
       - run: cargo build --workspace


### PR DESCRIPTION
Bump cloning action to get rid of some warnings.

Rust action has been abandoned for a long time and can't be bumped unfortunately: https://github.com/actions-rs/toolchain/issues/216

Caching added as well. Benchmarking this is hard, but:
* A clean rebuild gave me the fastest Linux build ever
* On Windows, the rebuild was OK in speed but not the fastest ever. However, even before the cache the Windows builds were taking between one and three minutes, so it's hard to know what effect the cache had here.

So I'll just keep the cache and hope for the best.