### PR TITLE
Add macports moar +pager variant support

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -242,6 +242,10 @@ fn highlight_stream(input: &mut dyn io::Read, no_pager: bool) {
         // doesn't exist.
     }
 
+    if try_pager(input, "moar-pager") {
+        return;
+    }
+
     if try_pager(input, "moar") {
         return;
     }


### PR DESCRIPTION
MacPorts now has a variant of the `moar` port which installs `moar` as
`moar-pager`. We are currently applying this patch during builds but
would prefer to avoid patching upstream builds if possible. This will
also prevent any other packaging system from needing to maintain
a similar patch should the take the approach that we have or something
similar.
