### PR TITLE
homebrew: only run homebrew bump per release

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -6,14 +6,6 @@ on:
       - "*"
 
 jobs:
-  homebrew:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Bump Homebrew formula
-        uses: dawidd6/action-homebrew-bump-formula@v3
-        with:
-          token: ${{secrets.JOHAN_GITHUB_API_TOKEN}}
-          formula: riff
   publish-to-cargo:
     name: Publishing to Cargo
     runs-on: ubuntu-latest

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,0 +1,15 @@
+name: Continuous Delivery
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  homebrew:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Bump Homebrew formula
+        uses: dawidd6/action-homebrew-bump-formula@v3
+        with:
+          token: ${{secrets.JOHAN_GITHUB_API_TOKEN}}
+          formula: riff


### PR DESCRIPTION
only the homebrew-core bumps per release, in this way the release notes would be also captured like this

![image](https://github.com/walles/riff/assets/1580956/83384891-b28a-4a07-a2c0-feb173b18b34)

It would also help to minimize the race conditions in the pull requests.

relates to:
- https://github.com/Homebrew/homebrew-core/pull/171064
- https://github.com/Homebrew/homebrew-core/pull/171063