### PR TITLE
Update AUR package name for riffdiff installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ unchanged line parts.
 brew install riff
 ```
 
-## With [Archlinux User Repository (AUR)](https://aur.archlinux.org/packages/riffdiff)
+## With [Archlinux User Repository (AUR)](https://aur.archlinux.org/packages/riffdiff-bin)
 
 ```
-paru -S riffdiff
+paru -S riffdiff-bin
 ```
 
 ## From [the Rust Crate](https://crates.io/crates/riffdiff)


### PR DESCRIPTION
The `riffdiff` AUR package isn't maintained anymore on archlinux, but someone upload a `riffdiff-bin` package which has clearly been updated to the latest version.

Fixes #77